### PR TITLE
Fix missing assignment in initFromJson for Option[T]

### DIFF
--- a/eminim.nim
+++ b/eminim.nim
@@ -224,7 +224,8 @@ proc initFromJson*[T](dst: var Option[T]; p: var JsonParser) =
     var tmp: T
     initFromJson(tmp, p)
     dst = some(tmp)
-  else: none[T]()
+  else:
+    dst = none[T]()
 
 proc detectIncompatibleType(typeExpr: NimNode) =
   if typeExpr.kind == nnkTupleConstr:


### PR DESCRIPTION
When attempting to deserialize into an `Option[T]`, I get:

```
C:\Users\Sebbert\.nimble\pkgs\eminim-2.5.1\eminim.nim(237, 16) Error: expression 'none()' is of type 'Option[system.string]' and has to be used (or discarded)
```

This PR adds the missing assignment here